### PR TITLE
add public description 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # talkr
+{talkr} offers a set of convenience functions for quality control, visualisation and analysis of conversational data. It is a companion to `scikit-talk`, a python package for processing conversational data.


### PR DESCRIPTION
add public-facing information about `talkr` in the form of (at least) a readme — solves #15 