### PR TITLE
Update tokenize functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,11 +29,10 @@ Imports:
     ggthemes,
     knitr,
     stats,
+    stringr,
     stringx,
     tidyr,
     tidyselect,
     tibble,
-    viridis,
-    stringr,
-    purrr
+    viridis
 Config/testthat/edition: 3

--- a/R/tokenize.R
+++ b/R/tokenize.R
@@ -29,26 +29,26 @@ tokenize <- function(data, utterancecol = "utterance") {
     dplyr::mutate(utterance_list = stringr::str_split(.data[[utterancecol]], " ")) |>
     tidyr::unnest(cols = "utterance_list") |>
     dplyr::rename(token = "utterance_list") |>
-    dplyr::filter(token != "") |>
-    dplyr::mutate(tokenorder = stats::ave(seq_along(uid), uid, FUN = seq_along))
+    dplyr::filter(.data$token != "") |>
+    dplyr::mutate(tokenorder = stats::ave(seq_along(.data$uid), .data$uid, FUN = seq_along))
 
   # count tokens per utterance
   count <- data |>
-    dplyr::group_by(uid) |>
+    dplyr::group_by(.data$uid) |>
     dplyr::summarise(nwords = dplyr::n())
 
   # merge timing data with token data and calculate timing
   data <- data |>
     dplyr::left_join(count, by = "uid") |>
-    dplyr::mutate(time_per_token = (end - begin) / nwords,
-                  starttime = begin + (0.5 * time_per_token),
-                  relative_time = round(starttime + (tokenorder - 1) * time_per_token, 0),
+    dplyr::mutate(time_per_token = (.data$end - .data$begin) / .data$nwords,
+                  starttime = .data$begin + (0.5 * .data$time_per_token),
+                  relative_time = round(.data$starttime + (.data$tokenorder - 1) * .data$time_per_token, 0),
                   order = dplyr::case_when(
-                    tokenorder == 1 & nwords == 1 ~ "only",
-                    tokenorder == 1 ~ "first",
-                    tokenorder == nwords ~ "last",
+                    .data$tokenorder == 1 & .data$nwords == 1 ~ "only",
+                    .data$tokenorder == 1 ~ "first",
+                    .data$tokenorder == .data$nwords ~ "last",
                     TRUE ~ "middle")) |>
-    dplyr::select(source, uid, participant, nwords, token, order, relative_time)
+    dplyr::select(.data$source, .data$uid, .data$participant, .data$nwords, .data$token, .data$order, .data$relative_time)
 
   return(data)
 }

--- a/man/tokenize.Rd
+++ b/man/tokenize.Rd
@@ -11,6 +11,9 @@ tokenize(data, utterancecol = "utterance")
 
 \item{utterancecol}{the name of the column containing the clean utterance (defaults to "utterance")}
 }
+\value{
+a dataframe with details about each token in the utterance
+}
 \description{
 From a dataframe with utterances, generate a dataframe that separates tokens
 in utterances, and assesses their relative timing.
@@ -26,5 +29,5 @@ the first token in the utterance beginning at the beginning of the utterance.
 The input column provided with the argument `utterancecol` is used to generate
 the tokens. It is advised to provide a version of the utterance that has been
 cleaned and stripped of special characters. Cleaning is not performed in this
-function. Spaces are used to separate words.
+function. Spaces are used to separate tokens.
 }

--- a/tests/testthat/test-tokenize.R
+++ b/tests/testthat/test-tokenize.R
@@ -7,6 +7,11 @@ test_that("token columns are created, dataset matches", {
   expect_true("uid" %in% colnames(tx))
   expect_true("nwords" %in% colnames(tx))
   expect_true("relative_time" %in% colnames(tx))
-  expect_equal(nrow(tx), 770)
-  expect_equal(ncol(tx), 6)
+  expect_true("order" %in% colnames(tx))
+  expect_equal(nrow(tx), 738)
+  expect_equal(ncol(tx), 7)
+
+  expect_equal(tx$relative_time[1:5], c(315271, 315796, 316320, 315414, 316067))
+  expect_equal(tx$token[1:5], c("high", "level", "eh?", "sí", "que"))
+  expect_equal(tx$order[1:4], c("first", "middle", "last", "only"))
 })


### PR DESCRIPTION
- tokens are timed not at the start of their estimated time slot, but in the middle 
- tokens are labeled with first/middle/last/only, depending on their order in the utterance
- fix for empty tokens (this happens when there are multiple spaces in the utterance; these are removed)