### PR TITLE
allow for source = NULL in a talkr init

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -6,7 +6,9 @@
 #' Initializing a talkr dataset is the first step in the talkr workflow.
 #'
 #' @param data A dataframe object
-#' @param source The column name identifying the conversation source (e.g. a filename; is used as unique conversation ID)
+#' @param source The column name identifying the conversation source
+#'  (e.g. a filename; is used as unique conversation ID). If there are no different
+#'  sources in the data, set this parameter to `NULL`.
 #' @param begin The column name with the begin time of the utterance (in milliseconds)
 #' @param end The column name with the end time of the utterance (in milliseconds)
 #' @param participant The column name with the participant who produced the utterance
@@ -41,6 +43,11 @@ init <- function(data,
   } else {
     data$begin <- as.numeric(data$begin)
     data$end <- as.numeric(data$end)
+  }
+
+  # ensure a `source` column exists; if it does not exist, create one
+  if(!"source" %in% names(data)){
+    data$source <- "talkr"
   }
 
   # generate UIDs

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -17,7 +17,9 @@ init(
 \arguments{
 \item{data}{A dataframe object}
 
-\item{source}{The column name identifying the conversation source (e.g. a filename; is used as unique conversation ID)}
+\item{source}{The column name identifying the conversation source
+(e.g. a filename; is used as unique conversation ID). If there are no different
+sources in the data, set this parameter to `NULL`.}
 
 \item{begin}{The column name with the begin time of the utterance (in milliseconds)}
 

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -130,3 +130,13 @@ test_that("init works with source = NULL", {
                      "talkr-0005-5")
   expect_equal(talkr_dataset$uid, expected_UIDs)
 })
+
+test_that("init does not overwrite existing columns when source = NULL", {
+  data <- data.frame(begin = 1:4,
+                     end = 5:8,
+                     participant = "Person1",
+                     utterance = "HelloWorld",
+                     source = "A.txt")
+  talkr_dataset <- init(data, source = NULL)
+  expect_equal(talkr_dataset$source, data$source)
+})

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -113,3 +113,20 @@ test_that("Warning is generated with existing UID column", {
   expect_true("original_uid" %in% names(talkr_dataset))
 
 })
+
+test_that("init works with source = NULL", {
+  expect_no_error(talkr_dataset <- init(dummy_data,
+                        source = NULL,
+                        begin = "col1",
+                        end = "col2",
+                        participant = "x",
+                        utterance = "y"))
+  expect_false("source" %in% names(dummy_data))
+  expect_true("source" %in% names(talkr_dataset))
+  expected_UIDs <- c("talkr-0001-1",
+                     "talkr-0002-2",
+                     "talkr-0003-3",
+                     "talkr-0004-4",
+                     "talkr-0005-5")
+  expect_equal(talkr_dataset$uid, expected_UIDs)
+})


### PR DESCRIPTION
Closes #69 

This PR adds the option for a source column to be NULL. If a dataset consists of a single conversation, the argument `source` can be set to NULL, and `talkr::init()` will create a source column from scratch, which is then used to create the UIDs.